### PR TITLE
Required Go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![1pa_demo4](https://user-images.githubusercontent.com/498852/43388441-fd6d1e92-939d-11e8-87b4-c05de73a66b7.gif)
 
 ## Installation
-1. [Install Go](https://golang.org/doc/install)
+1. [Install Go](https://golang.org/doc/install) (Go 1.8+ required)
 2. `go get -u github.com/vinc3m1/1pa`
 
 ## Usage


### PR DESCRIPTION
Currently, Go 1.7 is the available version on the Debian stretch repository. This is outdated as Go 1.12 is the current stable version, but it would be helpful to specify which version is necessary to build this project. This project fails under Go 1.7 where `sort.Slice` ([docs](https://golang.org/src/sort/slice.go?s=451:506#L7)) is undefined.

I believe the source of sort.Slice (found at the link) suggests that Go 1.8+ includes this standard function. 